### PR TITLE
Fix: wear os 에서 음성을 32000 byte 이상 받았을 때 데이터를 전송하여 Azure STT에서 음성을 인식 …

### DIFF
--- a/app/src/main/java/net/azurewebsites/soundsafeguard/service/DataClientService.kt
+++ b/app/src/main/java/net/azurewebsites/soundsafeguard/service/DataClientService.kt
@@ -48,6 +48,11 @@ class DataClientService(private val context: Context) : DataClient.OnDataChanged
      * Azure Speech to Text API를 사용하여 음성을 텍스트로 변환
      */
     private fun convertSpeechToText(audioData: ByteArray, language: String) {
+        val size=  audioData.size
+        val sampleData = audioData.take(size)
+        Log.d("AudioRecorderManager", "Audio data size: $size")
+        Log.d("AudioRecorderManager", "Audio sample data: $sampleData")
+
         CoroutineScope(Dispatchers.Main).launch {
             val result =
                 azureSTT.recognizeSpeechFromByteArray(audioData, language)


### PR DESCRIPTION
…오류를 해결하였다.

Azure STT에서 1초 이상의 음성을 인식할 수 있기 때문에 음성을 32000 byte 이상 받았을 때 모바일로 데이터를 보낸다.